### PR TITLE
Potential fix for code scanning alert no. 439: Missing rate limiting

### DIFF
--- a/backend/routes/systemFeedback.routes.js
+++ b/backend/routes/systemFeedback.routes.js
@@ -3,11 +3,18 @@ const router = express.Router();
 const systemFeedbackController = require('../controllers/systemFeedback.controller');
 const authenticate = require('../middleware/authMiddleware');
 const logger = require('../utils/logger');
+const rateLimit = require('express-rate-limit');
 
 logger.info('Loading system feedback routes...');
 
+// Rate limiter: maximum of 100 requests per 15 minutes
+const feedbackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
 // Root POST endpoint - authentication first, then controller
-router.post('/', authenticate, systemFeedbackController.submitFeedback);
+router.post('/', authenticate, feedbackLimiter, systemFeedbackController.submitFeedback);
 
 // Anonymous feedback endpoint - no authentication required
 router.post('/anonymous', systemFeedbackController.submitAnonymousFeedback);


### PR DESCRIPTION
Potential fix for [https://github.com/Austinkuria/attendance-system/security/code-scanning/439](https://github.com/Austinkuria/attendance-system/security/code-scanning/439)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library for this purpose. We will set up a rate limiter that restricts the number of requests a client can make to the `submitFeedback` endpoint within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/routes/systemFeedback.routes.js` file.
3. Configure the rate limiter with appropriate settings (e.g., maximum number of requests per minute).
4. Apply the rate limiter to the `submitFeedback` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
