### PR TITLE
Potential fix for code scanning alert no. 324: Use of externally-controlled format string

### DIFF
--- a/backend/controllers/session.controller.js
+++ b/backend/controllers/session.controller.js
@@ -171,7 +171,7 @@ exports.endSession = async (req, res) => {
       session: updatedSession
     });
   } catch (error) {
-    console.error(`Error ending session ${req.body.sessionId}:`, error);
+    console.error("Error ending session %s:", req.body.sessionId, error);
     res.status(500).json({ message: "Error ending session", error: error.message });
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Austinkuria/attendance-system/security/code-scanning/324](https://github.com/Austinkuria/attendance-system/security/code-scanning/324)

To fix the problem, we should ensure that the user-provided `sessionId` is safely included in the log message. This can be achieved by using a `%s` specifier in the format string and passing the `sessionId` as a separate argument to `console.error`. This approach ensures that the `sessionId` is treated as a string and avoids any potential issues with format specifiers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
