### PR TITLE
Potential fix for code scanning alert no. 327: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/feedback.controller.js
+++ b/backend/controllers/feedback.controller.js
@@ -26,7 +26,7 @@ exports.submitFeedback = async (req, res) => {
       return res.status(403).json({ message: 'Feedback can only be submitted for the latest session' });
     }
 
-    const existingFeedback = await Feedback.findOne({ sessionId, studentId });
+    const existingFeedback = await Feedback.findOne({ sessionId: { $eq: sessionId }, studentId });
     if (existingFeedback) {
       return res.status(400).json({ message: 'Feedback already submitted for this session' });
     }

--- a/backend/controllers/session.controller.js
+++ b/backend/controllers/session.controller.js
@@ -171,7 +171,7 @@ exports.endSession = async (req, res) => {
       session: updatedSession
     });
   } catch (error) {
-    console.error(`Error ending session ${req.body.sessionId}:`, error);
+    console.error("Error ending session %s:", req.body.sessionId, error);
     res.status(500).json({ message: "Error ending session", error: error.message });
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Austinkuria/attendance-system/security/code-scanning/327](https://github.com/Austinkuria/attendance-system/security/code-scanning/327)

To fix the problem, we need to ensure that the `sessionId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `sessionId` is interpreted as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
